### PR TITLE
No discharge

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject latte "0.3.7-SNAPSHOT"
+(defproject latte "0.4.0-SNAPSHOT"
   :description "LaTTe : a Laboratory for Type Theory Experiments"
   :url "https://github.com/fredokun/LaTTe.git"
   :license {:name "MIT Licence"

--- a/src/latte/classic.clj
+++ b/src/latte/classic.clj
@@ -43,10 +43,9 @@ This can be seen as an elimination rule for ¬¬ (not-not) propositions."
          (assume [z (not A)]
            (have d p/absurd :by (H z))
            (have e (==> p/absurd A) :by (p/ex-falso A))
-           (have f A :by (e d))
-           (have g (==> (not A) A) :discharge [z (f)]))
-         (have h A :by (c g))
-         (qed h)))
+           (have f A :by (e d)))
+         (have g A :by (c f))
+         (qed g)))
 
 
 (defthm not-not
@@ -75,16 +74,13 @@ classical logic."
       (assume [x A]
         (have a1 _ :by (p/or-intro-left A B))
         (have a2 (or A B) :by (a1 x))
-        (have a3 p/absurd :by (Hnot a2))
-        (have a (not A) :discharge [x a3]))
+        (have a p/absurd :by (Hnot a2)))
       (assume [y B]
         (have b1 _ :by (p/or-intro-right A B))
         (have b2 (or A B) :by (b1 y))
-        (have b3 p/absurd :by (Hnot b2))
-        (have b (not B) :discharge [y b3]))
+        (have b p/absurd :by (Hnot b2)))
       (have c B :by (H a))
-      (have d p/absurd :by (b c))
-      (have e (not (not (or A B))) :discharge [Hnot d]))
-    (have f (or A B) :by ((not-not-impl (or A B)) e))
-    (qed f)))
+      (have d p/absurd :by (b c)))
+    (have e (or A B) :by ((not-not-impl (or A B)) d))
+    (qed e)))
 

--- a/src/latte/equal.clj
+++ b/src/latte/equal.clj
@@ -36,8 +36,7 @@ This corresponds to Leibniz's *indiscernibility of identicals*."
            P (==> T :type)]
     (have a (<=> (P x) (P y)) :by (Heq P))
     (have b (<=> (P y) (P x)) :by ((p/iff-sym (P x) (P y)) a))
-    (have c _ :discharge [P b])
-    (qed c)))
+    (qed b)))
 
 (defthm eq-trans
   "The transitivity property of equality."
@@ -54,8 +53,7 @@ This corresponds to Leibniz's *indiscernibility of identicals*."
     (have b (<=> (P y) (P z)) :by (H2 P))
     (have c (<=> (P x) (P z))
           :by ((p/iff-trans (P x) (P y) (P z)) a b))
-    (have d _ :discharge [P c])
-    (qed d)))
+    (qed c)))
 
 (defthm eq-subst
   "Substitutivity property of equality."
@@ -82,13 +80,12 @@ This corresponds to Leibniz's *indiscernibility of identicals*."
            Q (==> U :type)]
     (assume [H2 (Q (f x))]
       (have a1 _ :by (eq-subst T (lambda [z T] (Q (f z))) x y))
-      (have a2 (Q (f y)) :by (a1 H1 H2))
-      (have a (==> (Q (f x)) (Q (f y))) :discharge [H2 a2]))
+      (have a (Q (f y)) :by (a1 H1 H2)))
     (have b (equal T y x) :by ((eq-sym T x y) H1))
     (assume [H3 (Q (f y))]
       (have c1 _ :by (eq-subst T (lambda [z T] (Q (f z))) y x))
-      (have c2 (Q (f x)) :by (c1 b H3))
-      (have c (==> (Q (f y)) (Q (f x))) :discharge [H3 c2]))
+      (have c (Q (f x)) :by (c1 b H3)))
     (have d (<=> (Q (f x)) (Q (f y))) :by ((p/iff-intro (Q (f x)) (Q (f y))) a c))
-    (have e (equal U (f x) (f y)) :discharge [Q d])
-    (qed e)))
+    (qed d)))
+
+

--- a/src/latte/fun.clj
+++ b/src/latte/fun.clj
@@ -82,10 +82,8 @@
       (have <b> (equal U (g x) (g y))
             :by (Hf (g x) (g y) <a>))
       (have <c> (equal T x y)
-            :by (Hg x y <b>))
-      (have <d> (injective T V (compose T U V f g))
-            :discharge [x y Hinj <c>]))
-    (qed <d>)))
+            :by (Hg x y <b>)))
+    (qed <c>)))
 
 (defthm injective-single
   "An injective function has at most one antecedent for each image."
@@ -105,11 +103,8 @@
                :by ((eq/eq-trans U (f x1) y (f x2))
                     Hx1
                     ((eq/eq-sym U (f x2) y) Hx2)))
-        (have <b> (equal T x1 x2) :by (Hf x1 x2 <a>))
-        (have <c> (q/single T (lambda [x T] (equal U (f x) y)))
-              :discharge [x1 x2 Hx1 Hx2 <b>]))
-      (have <d> _ :discharge [y <c>]))
-    (qed <d>)))
+        (have <b> (equal T x1 x2) :by (Hf x1 x2 <a>))))
+    (qed <b>)))
 
 (defthm bijective-unique
   "A bijective function has exactly one antecedent for each image."
@@ -215,12 +210,8 @@
                <b> <a>))
     (have <e> (equal U x y)
           :by ((eq/eq-trans U x (f (inv-f y)) y)
-               <d> <c>))
-    (have <f> (forall [x y U]
-                (==> (equal T (inv-f x) (inv-f y))
-                     (equal U x y)))
-          :discharge [x y Hxy <e>]))
-  (qed <f>))
+               <d> <c>)))
+  (qed <e>))
 
 (defthm inverse-bijective
   "The inverse of a bijection is a bijection."

--- a/src/latte/kernel/defs.clj
+++ b/src/latte/kernel/defs.clj
@@ -43,19 +43,12 @@
                 ;; use computed type
                 [:ok (->Definition def-name params (count params) body ty)]))))))))
 
-(defn handle-local-term-definition [def-name def-env ctx params body def-type]
-  (let [[status params] (reduce (fn [[sts params] [x ty]]
-                                  (let [[status ty] (stx/parse-term def-env ty)]
-                                    (if (= status :ko)
-                                      (reduced [:ko ty])
-                                      [:ok (conj params [x ty])]))) [:ok []] params)]
-    (if (= status :ko)
-      [:ko params]
-      (let [def-ty (loop [params params, def-ty def-type]
-                     (if (seq params)
-                       (recur (rest params) (list 'Π (first params) def-ty))
-                       def-ty))]
-        [:ok (->Definition def-name params (count params) body def-ty)]))))
+(defn handle-local-term-definition [def-name body def-type]
+  [:ok (->Definition def-name [] 0 body def-type)])
+
+(defn handle-local-term-discharge [local-def x ty]
+  (let [{def-name :name parsed-term :parsed-term type :type} local-def]
+    (->Definition def-name [] 0 (list 'λ [x ty] parsed-term) (list 'Π [x ty] type))))
 
 ;;{
 ;; ## Theorem definitions

--- a/src/latte/kernel/utils.clj
+++ b/src/latte/kernel/utils.clj
@@ -44,6 +44,13 @@
 (example
  (vectorn? [1 2 3 4 5 6 7] 4) => false)
 
+(defn safe-get
+  "A safe(r) variant of `get` for collections with non-`nil` keys."
+  [coll key]
+  (if-let [val (get coll key)]
+    val
+    (throw (ex-info "No such value is collection" {:coll coll :key key}))))
+
 
 
 

--- a/src/latte/prop.clj
+++ b/src/latte/prop.clj
@@ -47,8 +47,7 @@
            x A]
     (have <a> B :by (H1 x))
     (have <b> C :by (H2 <a>))
-    (have <c> (==> A C) :discharge [x <b>])
-    (qed <c>)))
+    (qed <b>)))
 
 (definition absurd
   "Absurdity."
@@ -158,8 +157,7 @@ Note that double-negation is a law of classical (non-intuitionistic) logic."
            z (==> A B C)]
     (have a (==> B C) :by (z x))
     (have b C :by ((a) y))
-    (have c (and A B) :discharge [C z b])
-    (qed c)))
+    (qed b)))
 
 (defspecial and-intro%
   "A special introduction rule that takes a proof
@@ -319,12 +317,7 @@ This is the introduction by the left operand."
            H1 (==> A C)
            H2 (==> B C)]
     (have a C :by (H1 x))
-    (have b (==> (==> B C) C) :discharge [H2 a])
-    (have c (==> (==> A C)
-                   (==> B C)
-                   C) :discharge [H1 b])
-    (have d (or A B) :discharge [C c])
-    (qed d)))
+    (qed a)))
 
 (defthm or-intro-right
   "Introduction rule for logical disjunction.
@@ -340,12 +333,7 @@ This is the introduction by the right operand."
            H1 (==> A C)
            H2 (==> B C)]
     (have a C :by (H2 y))
-    (have b (==> (==> B C) C) :discharge [H2 a])
-    (have c (==> (==> A C)
-                   (==> B C)
-                   C) :discharge [H1 b])
-    (have d (or A B) :discharge [C c])
-    (qed d)))
+    (qed a)))
 
 (defthm or-elim
   "Elimination rule for logical disjunction.
@@ -391,10 +379,9 @@ This eliminates to the left operand."
     (have <b> (==> A A) :by (impl-refl A))
     (assume [x B]
       (have <c> absurd :by (H2 x))
-      (have <d> A :by (<c> A))
-      (have <e> (==> B A) :discharge [x <d>]))
-    (have <f> A :by (<a> <b> <e>))
-    (qed <f>)))
+      (have <d> A :by (<c> A)))
+    (have <e> A :by (<a> <b> <d>))
+    (qed <e>)))
 
 (defthm or-not-elim-right
   "An elimination rule for disjunction, simpler than [[or-elim]].
@@ -411,10 +398,9 @@ This eliminates to the right operand."
     (have <b> (==> B B) :by (impl-refl B))
     (assume [x A]
       (have <c> absurd :by (H2 x))
-      (have <d> B :by (<c> B))
-      (have <e> (==> A B) :discharge [x <d>]))
-    (have <f> B :by (<a> <e> <b>))
-    (qed <f>)))
+      (have <d> B :by (<c> B)))
+    (have <e> B :by (<a> <d> <b>))
+    (qed <e>)))
 
 (defthm or-sym
   "Symmetry of disjunction.
@@ -428,16 +414,11 @@ characteristic of or-elimination."
 (proof or-sym :script
   (assume [H1 (or A B)
            D :type
-           H2 (==> A D)
-           H3 (==> B D)]
+           H2 (==> B D)
+           H3 (==> A D)]
     (have a _ :by (H1 D))
-    (have b D :by (a H2 H3))
-    (have c (==> (==> A D) D) :discharge [H2 b])
-    (have d (==> (==> B D)
-                 (==> A D)
-                 D) :discharge [H3 c])
-    (have e (or B A) :discharge [D d])
-    (qed e)))
+    (have b D :by (a H3 H2))
+    (qed b)))
 
 (defthm or-not-impl-elim
   "An alternative elimination rule for disjunction."
@@ -447,18 +428,17 @@ characteristic of or-elimination."
 
 (proof or-not-impl-elim :script
   (assume [H (or A B)
-           Hn (not A)
-           x A]
-    (have a absurd :by (Hn x))
-    "Thanks to absurdity we can get anything we want."
-    (have b B :by (a B))
-    (have c (==> A B) :discharge [x b])
-    (have d (==> B B) :by (impl-refl B))
-    (have e (==> (==> A B)
+           Hn (not A)]
+    (assume [x A]
+      (have a absurd :by (Hn x))
+      "Thanks to absurdity we can get anything we want."
+      (have b B :by (a B)))
+    (have c (==> B B) :by (impl-refl B))
+    (have d (==> (==> A B)
                  (==> B B)
                  B) :by (H B))
-    (have f B :by (e c d))
-    (qed f)))
+    (have e B :by (d b c))
+    (qed e)))
 
 (definition <=>
   "Logical equivalence or 'if and only if'."
@@ -569,3 +549,5 @@ characteristic of or-elimination."
     (have i _ :by (iff-intro A C))
     (have k (<=> A C) :by (i d h))
     (qed k)))
+
+

--- a/src/latte/quant.clj
+++ b/src/latte/quant.clj
@@ -71,12 +71,7 @@ Remark: this is a second-order, intuitionistic definition that
            y (forall [z T] (==> (P z) A))]
     (have a (==> (P x) A) :by (y x))
     (have b A :by (a H))
-    (have c (==> (forall [z T] (==> (P z) A))
-                 A) :discharge [y b])
-    (have d (forall [A :type]
-              (==> (forall [z T] (==> (P z) A))
-                   A)) :discharge [A c])
-    (qed d)))
+    (qed b)))
 
 (definition single
   "The constraint that \"there exists at most\"..."
@@ -122,8 +117,6 @@ Remark: this is a second-order, intuitionistic definition that
     (have c (==> (P y)
                  (P (the T P u))
                  (equal T y (the T P u))) :by (a y (the T P u)))
-    (have d (equal T y (the T P u)) :by (c Hy b))
-    (have e _ :discharge [Hy d])
-    (have f _ :discharge [y e]))
-  (qed f))
+    (have d (equal T y (the T P u)) :by (c Hy b)))
+  (qed d))
 


### PR DESCRIPTION
The explicit discharge of assumptions with `(have <.> T :discharge [H1 H2 .... t])` have been removed. Now assumptions are discharged automatically when closing the `(assume [...] ...)` scopes. The only inconvenience is that the assumption order must be though about in advance, but overally the implicit approach is better.