### PR TITLE
Add Clojure tools deps + Circle CI 

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,9 @@
+version: 2
+jobs:
+  build:
+    working_directory: ~/LaTTe
+    docker:
+      - image: circleci/clojure:openjdk-11-tools-deps-1.10.0.442
+    steps:
+      - checkout
+      - run: clojure -A:test

--- a/.gitignore
+++ b/.gitignore
@@ -10,4 +10,5 @@ pom.xml.asc
 .lein-plugins/
 .lein-failures
 .nrepl-port
+.cpcache
 *~

--- a/README.md
+++ b/README.md
@@ -15,8 +15,8 @@ http://latte-central.github.io/LaTTe/
 
 **LaTTe** : a Laboratory for Type Theory experiments (in clojure)
 
-[![Clojars Project](https://img.shields.io/clojars/v/latte.svg)](https://clojars.org/latte)
 
+[![CircleCI](https://circleci.com/gh/zampino/LaTTe/tree/depsify.svg?style=svg)](https://circleci.com/gh/zampino/LaTTe/tree/depsify) [![Clojars Project](https://img.shields.io/clojars/v/latte.svg)](https://clojars.org/latte)
 ## What?
 
 LaTTe is a **proof assistant library** based on type theory (a variant of

--- a/README.md
+++ b/README.md
@@ -23,11 +23,11 @@ LaTTe is a **proof assistant library** based on type theory (a variant of
 λD as described in the book [Type theory and formal proof: an introduction](http://www.cambridge.org/fr/academic/subjects/computer-science/programming-languages-and-applied-logic/type-theory-and-formal-proof-introduction)).
 
  - **Hot!** Watch Latte *live* at: https://www.youtube.com/watch?v=5YTCY7wm0Nw
- 
+
  - **Sizzling!** A paper about LaTTe at the European Lisp Symposium, 2017:
-   https://github.com/latte-central/latte-ELS-2017 
+   https://github.com/latte-central/latte-ELS-2017
    [[PDF]](https://github.com/latte-central/latte-ELS-2017/blob/master/paper/latte-els-2017.pdf)
-   
+
  - **Blistering** LaTTe was in the [Hacker news!](https://news.ycombinator.com/item?id=18383654)
 
 The specific feature of LaTTe is its design as a library (unlike most proof assistant, generally designed as tools) tightly integrated with the Clojure language. It is of course fully implemented in Clojure, but most importantly all the definitional aspects of the assistant (definitions, theorem and axioms) are handled using Clojure namespaces, definitions and macros.
@@ -70,7 +70,7 @@ The proof of the theorem can be also constructed as a Clojure form:
 > assuming `A` holds, as an hypothesis named `x`
 > we can deduce `A` by `x`
 > hence `A` implies `A` as stated (QED).
-  
+
 Of course, all the proofs are *checked for correctness*. Without the introduction
  of an inconsistent axiom (and assuming the correctness of the implementation of the LaTTe kernel),
  *no mathematical inconsistency* can be introduced by the `proof` form.
@@ -85,13 +85,13 @@ Given the tight integration with the Clojure language, *existing* Clojure develo
  - There will be a *tutorial* at some point ...
 
  - The *reference documentation* is at: http://latte-central.github.io/LaTTe/
- 
-**Standard library** : 
- 
+
+**Standard library** :
+
  - The **prelude** library is at: https://github.com/latte-central/latte-prelude
- 
+
  - The **(typed) sets** library is at: https://github.com/latte-central/latte-sets
- 
+
  - The **integer arithmetic** library is at: https://github.com/latte-central/latte-integers
 
 (obviously more to come ...)
@@ -114,5 +114,18 @@ A few non-trivial formalizations have been conducted using LaTTe:
 
 Contributions such as mathematical content or enhancement/correction of the underlying machinery are very much welcomed.
 
+## Build
+
+Running Tests
+
+```
+clj -A:test
+```
+
+Building Documentation
+
+```
+clj -A:codox
+```
 ----
 Copyright (C) 2015-2018 Frederic Peschanski (MIT license, cf. `LICENSE`)

--- a/codox/codox.clj
+++ b/codox/codox.clj
@@ -1,0 +1,24 @@
+(ns codox
+  "Codox Runner to be operated via Clojure CLI
+
+   Usage: clj -A:codox"
+  (:gen-class)
+  (:require [codox.main :as codox]
+            [latte.core]))
+
+(def options
+  {:source-paths ["src"]
+   :output-path "docs"
+   :metadata {:doc/format :markdown}
+   :namespaces ['latte.core]
+   :name "LaTTe"
+   :license {:name "MIT Licence"
+             :url "http://opensource.org/licenses/MIT"}
+   #_#_
+   :root-path "src"
+   :description "LaTTe : a Laboratory for Type Theory Experiments"
+   :version "1.0b4-SNAPSHOT"})
+
+(defn -main []
+  (println "Codox Starting")
+  (codox/generate-docs options))

--- a/deps.edn
+++ b/deps.edn
@@ -1,0 +1,20 @@
+{:paths ["src"]
+ :deps
+ {org.clojure/clojure {:mvn/version "1.10.1"}
+  org.clojure/core.match {:mvn/version "0.3.0"}
+  digest {:mvn/version "1.4.9"}
+  com.taoensso/timbre {:mvn/version "4.10.0"}
+  latte-kernel {:mvn/version "1.0b4-SNAPSHOT"}}
+
+ :aliases
+ {:codox
+  {:extra-paths ["src" "codox"]
+   :main-opts ["-m" "codox"]
+   :extra-deps {codox {:mvn/version "0.10.7"}}}
+
+  :test
+  {:extra-paths ["test"]
+   :extra-deps {lambdaisland/kaocha {:mvn/version "0.0-541"}}
+   :main-opts ["-m" "kaocha.runner"
+               "--reporter" "kaocha.report/documentation"
+               "--plugin" "kaocha.plugin/print-invocations"]}}}


### PR DESCRIPTION
This allows to build the project using Clojure's native [clojure tools deps](https://clojure.org/reference/deps_and_cli) a somehow more modern replacement of leiningen. 

I added a new `deps.edn` file with two aliases one for running codox (needed a mini runner script) and one for running tests i.e. with [clojure native binary tools](https://clojure.org/guides/getting_started) we can run:

```
clj -A:codox
```
or
```
clj -A:test
```

With a `deps.edn` file in the project dir it will be also possible to source LaTTe in other projects pointing at a specific git sha, for building specific features not yet published to clojars.

This pr also adds a minimal configuration for running the test suite on Circle CI (I'll need to grant org permissions to Circle if it's not a problem).